### PR TITLE
Preserving RemoteAddr from original request

### DIFF
--- a/interceptor_http.go
+++ b/interceptor_http.go
@@ -29,6 +29,8 @@ func (ic *interceptor) http(req *http.Request, forwardInitialRequest bool, op op
 func (ic *interceptor) httpUp(req *http.Request, forwardInitialRequest bool, op ops.Op, downstream net.Conn, downstreamBuffered *bufio.ReadWriter, upstream net.Conn, requests chan *http.Request) {
 	defer close(requests)
 
+	remoteAddr := req.RemoteAddr
+
 	var readErr error
 	first := true
 	for {
@@ -60,6 +62,8 @@ func (ic *interceptor) httpUp(req *http.Request, forwardInitialRequest bool, op 
 			}
 			break
 		}
+		// Preserve remote address from original request
+		req.RemoteAddr = remoteAddr
 		first = false
 	}
 }

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -82,9 +82,16 @@ func doTest(t *testing.T, op ops.Op, requestMethod string, pipe bool, forwardIni
 			resp.Header.Set(okHeader, "I'm OK!")
 			return resp
 		},
+		OnRequest: func(req *http.Request) *http.Request {
+			if req.RemoteAddr == "" {
+				t.Fatal("Request missing RemoteAddr!")
+			}
+			return req
+		},
 	})
 
 	req, _ := http.NewRequest(requestMethod, "http://thehost", nil)
+	req.RemoteAddr = "remoteaddr:134"
 	i.Intercept(w, req, forwardInitialRequest, op, 756)
 
 	assert.Equal(t, "thehost:756", d.LastDialed(), "Should have defaulted port to 756")


### PR DESCRIPTION
Another config related issue. If we get a 2nd config request on a persistent connection, it was missing the RemoteAddr.